### PR TITLE
Remove space fields from js container handler

### DIFF
--- a/src/Resources/public/merger2.js
+++ b/src/Resources/public/merger2.js
@@ -60,7 +60,5 @@ $(window).addEvent('domready', function () {
     $('opt_merger_container_0').addEvent('change', function () {
         $('ctrl_cssID_0').disabled = !this.checked;
         $('ctrl_cssID_1').disabled = !this.checked;
-        $('ctrl_space_0').disabled = !this.checked;
-        $('ctrl_space_1').disabled = !this.checked;
     });
 });


### PR DESCRIPTION
Hotfix js container
space in Contao 4 obsolete - delete JS error