### PR TITLE
Use twig instead of templating component and update multicolumnwizard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,14 +34,15 @@
     "php": ">=7.1",
     "ext-json": "~1.2",
     "contao/core-bundle": "~4.4",
-    "menatwork/contao-multicolumnwizard": "^3.3.4",
+    "menatwork/contao-multicolumnwizard-bundle": "^3.3.4",
     "suncat/mobile-detect-bundle":"^1.0.0",
     "symfony/config": "^3.0 || ^4.0 ",
     "symfony/dependency-injection": "^3.0 || ^4.0",
     "symfony/http-kernel": "^3.0 || ^4.0",
-    "symfony/templating": "^3.0 || ^4.0",
+    "symfony/twig-bundle": "^3.0 || ^4.0",
     "symfony/translation": "^3.0 || ^4.0",
-    "symfony/yaml": "^3.0 || ^4.0"
+    "symfony/yaml": "^3.0 || ^4.0",
+    "twig/twig": "^2.0 || ^1.35.0"
   },
   "require-dev": {
     "phpcq/all-tasks": "~1.0",

--- a/src/EventListener/Hook/LoadFunctionExplanationsListener.php
+++ b/src/EventListener/Hook/LoadFunctionExplanationsListener.php
@@ -6,7 +6,7 @@
  * @package   Merger²
  * @author    David Molineus <david.molineus@netzmacht.de>
  * @copyright 2013-2014 bit3 UG
- * @copyright 2015-2018 Contao Community Alliance
+ * @copyright 2015-2019 Contao Community Alliance
  * @license   https://github.com/contao-community-alliance/merger2/blob/master/LICENSE LGPL-3.0-or-later
  * @link      https://github.com/contao-community-alliance/merger2
  */
@@ -15,9 +15,8 @@ declare(strict_types=1);
 
 namespace ContaoCommunityAlliance\Merger2\EventListener\Hook;
 
-use ContaoCommunityAlliance\Merger2\Functions\Description\Argument;
 use ContaoCommunityAlliance\Merger2\Functions\FunctionCollection;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * Class LoadFunctionExplanationsListener generated the functions explanations at runtime.
@@ -34,24 +33,24 @@ final class LoadFunctionExplanationsListener
     private $functions;
 
     /**
-     * The templating engine.
+     * The twig environment.
      *
-     * @var EngineInterface
+     * @var Environment
      */
-    private $templating;
+    private $twig;
 
     /**
      * LoadFunctionExplanationsListener constructor.
      *
-     * @param FunctionCollection $functions  The function collection.
-     * @param EngineInterface    $templating The templating engine.
+     * @param FunctionCollection $functions The function collection.
+     * @param Environment        $twig      The twig templating engine.
      */
     public function __construct(
         FunctionCollection $functions,
-        EngineInterface $templating
+        Environment $twig
     ) {
-        $this->functions  = $functions;
-        $this->templating = $templating;
+        $this->functions = $functions;
+        $this->twig      = $twig;
     }
 
     /**
@@ -83,7 +82,7 @@ final class LoadFunctionExplanationsListener
     private function renderExplanation(string $language): string
     {
         $descriptions = $this->functions->getDescriptions();
-        $explanation  = $this->templating->render(
+        $explanation  = $this->twig->render(
             '@CcaMerger2/explanation.html5.twig',
             [
                 'descriptions' => $descriptions,

--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -5,4 +5,4 @@ services:
   ContaoCommunityAlliance\Merger2\EventListener\Hook\LoadFunctionExplanationsListener:
     arguments:
       - '@cca.merger2.function_collection'
-      - '@templating'
+      - '@twig'


### PR DESCRIPTION
Instead of using the templating component to render twig templates
twig is used directly (templating component got deprecated).

Now the multi column wizard bundle is required instead of the old
Contao 3 compatible module.