### PR TITLE
Do not use mobile detect bundle anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+ - Do not require `suncat/mobile-detect-bundle` anymore but require `mobiledetect/mobiledetectlib` 
+
+
+[Unreleased]: https://github.com/contao-community-alliance/merger2/compare/4.0.7...develop

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Requirements
 
 Merger² v4 requires at least Contao 4.4 with PHP 7.1 and is prepared for the Contao Managed Edition.
 
+
+Changelog
+---------
+
+See [CHANGELOG](CHANGELOG.md)
+
 Documentation
 -------------
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "ext-json": "~1.2",
     "contao/core-bundle": "~4.4",
     "menatwork/contao-multicolumnwizard-bundle": "^3.3.4",
-    "suncat/mobile-detect-bundle": "^1.0.0",
+    "mobiledetect/mobiledetectlib": "~2.8",
     "symfony/config": "^3.0 || ^4.0",
     "symfony/dependency-injection": "^3.0 || ^4.0",
     "symfony/http-kernel": "^3.0 || ^4.0",

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -20,7 +20,6 @@ use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use ContaoCommunityAlliance\Merger2\CcaMerger2Bundle;
-use SunCat\MobileDetectBundle\MobileDetectBundle;
 
 /**
  * Contao Manager plugin.
@@ -35,10 +34,9 @@ final class Plugin implements BundlePluginInterface
     public function getBundles(ParserInterface $parser)
     {
         return [
-            BundleConfig::create(MobileDetectBundle::class),
             BundleConfig::create(CcaMerger2Bundle::class)
                 ->setReplace(['merger2'])
-                ->setLoadAfter([ContaoCoreBundle::class, MobileDetectBundle::class])
+                ->setLoadAfter([ContaoCoreBundle::class])
         ];
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -13,6 +13,9 @@ services:
     arguments:
       - []
 
+  cca.merger2.mobile_detect:
+    class: Detection\MobileDetect
+
   cca.merger2.function.article_exists:
     class: ContaoCommunityAlliance\Merger2\Functions\ArticleExistsFunction
     arguments:
@@ -70,7 +73,7 @@ services:
   cca.merger2.function.platform:
     class: ContaoCommunityAlliance\Merger2\Functions\PlatformFunction
     arguments:
-      - '@mobile_detect.mobile_detector'
+      - '@cca.merger2.mobile_detect'
     tags:
       - { name: 'cca.merger2.function'}
 


### PR DESCRIPTION
The mobile detect bundle provides a cookie based method to switch the view. It's not required, because Contao provides it's own method. And for cache optimization the extra cookie should not be set.

As it's not possible to disable the cookie in the bundle, we use the mobile detect library directly. If someone required the mobile detect bundle one should have required it self, so it can be safely removed as dependencies in a feature release.